### PR TITLE
Investigate link generation for little microphones page

### DIFF
--- a/api/get-share-link.js
+++ b/api/get-share-link.js
@@ -8,7 +8,7 @@
  * GET /api/get-share-link?lmid=38&world=spookyland
  * 
  * RESPONSE FORMAT:
- * { success: true, shareId: "kz7xp4v9", url: "https://domain.com/members/radio?ID=kz7xp4v9", world: "spookyland" }
+ * { success: true, shareId: "kz7xp4v9", url: "https://domain.com/little-microphones?ID=kz7xp4v9", world: "spookyland" }
  * 
  * LOGIC:
  * 1. Validate LMID and world parameters
@@ -170,7 +170,7 @@ export default async function handler(req, res) {
         const baseUrl = req.headers.host?.includes('localhost') 
             ? `http://${req.headers.host}` 
             : `https://${req.headers.host}`;
-        const shareableUrl = `${baseUrl}/members/radio?ID=${shareId}`;
+        const shareableUrl = `${baseUrl}/little-microphones?ID=${shareId}`;
 
         return res.status(200).json({
             success: true,

--- a/documentation/rp.js.md
+++ b/documentation/rp.js.md
@@ -44,7 +44,7 @@ newButton.addEventListener('click', async (event) => {
 async function generateShareIdAndSetupButton(button, world, lmid) {
   // Pre-generate ShareID during page load
   const response = await fetch('/api/get-share-link');
-  const radioUrl = `/members/radio?ID=${result.shareId}`;
+  const radioUrl = `/little-microphones?ID=${result.shareId}`;
   
   // Set as direct link (works on mobile)
   button.setAttribute('href', radioUrl);
@@ -98,7 +98,7 @@ memberstack.getCurrentMember()
 ### ShareID System
 - **Unique Identifiers**: Each world/lmid combination gets a unique ShareID
 - **Database Storage**: ShareIDs stored in Supabase for persistence
-- **URL Format**: `/members/radio?ID=shareId` (no exposed world/lmid)
+- **URL Format**: `/little-microphones?ID=shareId` (no exposed world/lmid)
 
 ### Mobile Compatibility Improvements
 **Problem Solved**: Mobile browsers often block `window.open()` calls that aren't directly triggered by user interaction.


### PR DESCRIPTION
Correct ShareID link generation to use `/little-microphones` instead of `/members/radio`.

The API was generating `/members/radio?ID=shareId` URLs, but the frontend expected `/little-microphones?ID=shareId`, leading to broken play icon links on program cards. This change aligns the API output with the frontend's expectation and updates related documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7e203e4-3c1c-47e2-bd30-5f7269e4aeea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7e203e4-3c1c-47e2-bd30-5f7269e4aeea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

